### PR TITLE
Change font-weight to 500 for section p

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -136,7 +136,7 @@ section {
     padding-bottom:50px;
 }
 section p, section pre, section ul { margin-bottom:1.6em; }
-section p { font-weight:300; text-align:justify;}
+section p { font-weight:500; text-align:justify;}
 
 article { padding-top:1em; }
 aside#related li { padding-top:1em; line-height: 1.5;}


### PR DESCRIPTION
On Windows, font-weight 300 at that font size with default DPI is mostly broken.  Below are comparison screenshots, with 300 on the left and 500 on the right.  Only Firefox renders it acceptably.  [(imgur album)](http://imgur.com/a/xysTo)
#### Chrome 28

![](http://i.imgur.com/onwb0Av.png)
#### Firefox 25.0a1

![](http://i.imgur.com/WQYPSGA.png)
#### Opera 12.16

![](http://i.imgur.com/seJE33l.png)
#### Opera Next

![](http://i.imgur.com/FCkbUZe.png)
