### PR TITLE
Fix Sass compilation for LibSass compatibility

### DIFF
--- a/_sass/_custom-hero.scss
+++ b/_sass/_custom-hero.scss
@@ -9,7 +9,7 @@
     display: block;
     width: 100%;
     height: auto;
-    aspect-ratio: 1200 / 630;
+    aspect-ratio: #{"1200 / 630"};
     object-fit: cover;
     border-radius: 0;
   }

--- a/_sass/_custom-typography.scss
+++ b/_sass/_custom-typography.scss
@@ -26,7 +26,7 @@
 }
 
 html {
-  font-size: clamp(16px, 1rem + 0.25vw, 19px);
+  font-size: #{clamp(16px, 1rem + 0.25vw, 19px)};
 }
 
 body {
@@ -45,10 +45,10 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--color-text);
 }
 
-h1 { font-size: clamp(1.6rem, 4vw, 2.4rem); }
-h2 { font-size: clamp(1.3rem, 3vw, 1.8rem); }
-h3 { font-size: clamp(1.1rem, 2.5vw, 1.4rem); }
-h4 { font-size: clamp(1rem, 2vw, 1.2rem); }
+h1 { font-size: #{clamp(1.6rem, 4vw, 2.4rem)}; }
+h2 { font-size: #{clamp(1.3rem, 3vw, 1.8rem)}; }
+h3 { font-size: #{clamp(1.1rem, 2.5vw, 1.4rem)}; }
+h4 { font-size: #{clamp(1rem, 2vw, 1.2rem)}; }
 
 code, pre, kbd, samp {
   font-family: "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas,

--- a/_sass/_custom-video.scss
+++ b/_sass/_custom-video.scss
@@ -8,14 +8,14 @@
 
   lite-youtube {
     width: 100%;
-    aspect-ratio: 16 / 9;
+    aspect-ratio: #{"16 / 9"};
     border-radius: 8px;
     overflow: hidden;
   }
 
   iframe {
     width: 100%;
-    aspect-ratio: 16 / 9;
+    aspect-ratio: #{"16 / 9"};
     border: none;
     border-radius: 8px;
   }


### PR DESCRIPTION
## Summary

Fix Jekyll build failure caused by LibSass (used by `github-pages` gem) not supporting modern CSS functions:

- **`clamp()`** with mixed units (`rem + vw`) — LibSass tries to evaluate at compile time → wrapped in `#{}` interpolation
- **`aspect-ratio: 16 / 9`** — LibSass interprets `/` as division → wrapped in `#{"..."}` string interpolation

## Files changed
- `_sass/_custom-typography.scss` — 5 `clamp()` expressions
- `_sass/_custom-hero.scss` — 1 `aspect-ratio`
- `_sass/_custom-video.scss` — 2 `aspect-ratio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)