### PR TITLE
Harden LinkedIn posting + upgrade to Gemini 2.5 Pro

### DIFF
--- a/.github/scripts/post_to_linkedin.py
+++ b/.github/scripts/post_to_linkedin.py
@@ -108,7 +108,7 @@ Requirements:
 
 Return ONLY the LinkedIn post text, nothing else."""
 
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={api_key}"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key={api_key}"
 
     payload = json.dumps({
         "contents": [{"parts": [{"text": prompt}]}],
@@ -134,6 +134,58 @@ Return ONLY the LinkedIn post text, nothing else."""
                 return parts[0]["text"].strip()
 
     return None
+
+
+def check_already_posted(post_title):
+    """Check if a LinkedIn post was already made for this blog post.
+
+    Looks for an existing GitHub Issue comment containing 'LinkedIn post'
+    on the matching issue. This prevents duplicate LinkedIn posts on
+    re-runs, retries, or workflow_dispatch.
+    """
+    gh_token = os.environ.get("GH_TOKEN", os.environ.get("GITHUB_TOKEN", ""))
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+
+    if not gh_token or not repo:
+        return False  # Can't check, proceed cautiously
+
+    # Search for matching open issue
+    search_title = post_title.replace('"', '\\"')
+    url = f"https://api.github.com/search/issues?q=repo:{repo}+is:issue+%22{urllib.parse.quote(search_title)}%22"
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {gh_token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+            for issue in data.get("items", []):
+                # Check comments on this issue for LinkedIn post link
+                comments_url = issue.get("comments_url", "")
+                if not comments_url:
+                    continue
+                req2 = urllib.request.Request(
+                    comments_url,
+                    headers={
+                        "Authorization": f"Bearer {gh_token}",
+                        "Accept": "application/vnd.github+json",
+                    },
+                )
+                with urllib.request.urlopen(req2) as resp2:
+                    comments = json.loads(resp2.read())
+                    for comment in comments:
+                        if "linkedin.com" in comment.get("body", "").lower():
+                            print(f"LinkedIn post already exists for '{post_title}' — skipping")
+                            return True
+    except Exception as e:
+        print(f"Deduplication check failed ({e}), proceeding")
+
+    return False
 
 
 def check_token_validity(access_token, client_id, client_secret):
@@ -273,6 +325,10 @@ def main():
 
     print(f"Generating LinkedIn copy for: {title}")
     print(f"Post URL: {post_url}")
+
+    # Deduplication: skip if LinkedIn was already posted for this article
+    if check_already_posted(title):
+        sys.exit(0)
 
     if not api_key:
         print("GOOGLE_API_KEY not set, using fallback LinkedIn copy")

--- a/.github/scripts/transcribe.py
+++ b/.github/scripts/transcribe.py
@@ -92,7 +92,7 @@ def upload_audio_to_gemini(audio_path, api_key):
 
 def transcribe_with_gemini(file_uri, api_key, post_title):
     """Use Gemini to transcribe the audio with timestamps."""
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={api_key}"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key={api_key}"
 
     prompt = f"""Transcribe this audio recording in full. This is a vlog/talk titled "{post_title}".
 

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,16 +32,39 @@ jobs:
       - name: Detect new posts
         id: detect
         run: |
-          # Find newly added posts in this commit
-          NEW_POST=$(git diff --name-only --diff-filter=A HEAD~1 HEAD -- '_posts/' | head -1)
-          if [ -n "$NEW_POST" ]; then
-            echo "new_post=$NEW_POST" >> $GITHUB_OUTPUT
-            # Extract title from frontmatter
-            TITLE=$(grep -m1 '^title:' "$NEW_POST" | sed 's/^title: *"*//;s/"*$//')
-            echo "post_title=$TITLE" >> $GITHUB_OUTPUT
-            SLUG=$(basename "$NEW_POST" .md | sed 's/^[0-9-]*//')
-            echo "post_slug=$SLUG" >> $GITHUB_OUTPUT
+          # Only detect genuinely new posts:
+          # 1. File must be newly Added in _posts/ (not modified)
+          # 2. File's date prefix must be today or yesterday (catches timezone edge cases)
+          # 3. Skip workflow_dispatch re-runs (no new commit = no diff)
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — skipping new post detection"
+            exit 0
           fi
+
+          NEW_POST=$(git diff --name-only --diff-filter=A HEAD~1 HEAD -- '_posts/' | head -1)
+
+          if [ -z "$NEW_POST" ]; then
+            echo "No new posts in this commit"
+            exit 0
+          fi
+
+          # Verify the post date is recent (today or yesterday)
+          FILE_DATE=$(basename "$NEW_POST" | grep -oP '^\d{4}-\d{2}-\d{2}')
+          TODAY=$(date -u +%Y-%m-%d)
+          YESTERDAY=$(date -u -d "yesterday" +%Y-%m-%d 2>/dev/null || date -u -v-1d +%Y-%m-%d)
+
+          if [ "$FILE_DATE" != "$TODAY" ] && [ "$FILE_DATE" != "$YESTERDAY" ]; then
+            echo "Post date $FILE_DATE is not recent — skipping LinkedIn (likely a bulk import or old file)"
+            exit 0
+          fi
+
+          echo "new_post=$NEW_POST" >> $GITHUB_OUTPUT
+          TITLE=$(grep -m1 '^title:' "$NEW_POST" | sed 's/^title: *"*//;s/"*$//')
+          echo "post_title=$TITLE" >> $GITHUB_OUTPUT
+          SLUG=$(basename "$NEW_POST" .md | sed 's/^[0-9-]*//')
+          echo "post_slug=$SLUG" >> $GITHUB_OUTPUT
+          echo "Detected new post: $NEW_POST (date: $FILE_DATE)"
 
       - name: Check for missing header images
         id: check
@@ -130,6 +153,8 @@ jobs:
           LINKEDIN_PERSON_URN: ${{ secrets.LINKEDIN_PERSON_URN }}
           LINKEDIN_CLIENT_ID: ${{ secrets.LINKEDIN_CLIENT_ID }}
           LINKEDIN_CLIENT_SECRET: ${{ secrets.LINKEDIN_CLIENT_SECRET }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           POST_FILE: ${{ needs.process-images.outputs.new_post }}
           SITE_URL: "https://blog.heusingfeld.de"
         run: python3 .github/scripts/post_to_linkedin.py


### PR DESCRIPTION
## Summary

**Anti-spam safeguards** — three layers to prevent duplicate LinkedIn posts:
1. **Workflow level**: Skip detection on `workflow_dispatch` (manual re-runs)
2. **Workflow level**: Verify the post's date prefix is today or yesterday — rejects bulk imports of old files
3. **Script level**: Before posting, query GitHub Issues for existing comments containing `linkedin.com` — catches retries and re-runs that pass the workflow checks

**Model upgrade**: Switch from Gemini 2.0 Flash to **Gemini 2.5 Pro** for LinkedIn copy generation and vlog transcription — more thoughtful, nuanced output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)