### PR TITLE
Fix LibSass compilation + upgrade to Gemini 3 Pro

### DIFF
--- a/.github/scripts/generate_header_image.py
+++ b/.github/scripts/generate_header_image.py
@@ -73,19 +73,19 @@ def generate_image_with_gemini(title, excerpt, api_key):
                 return base64.b64decode(predictions[0]["bytesBase64Encoded"])
     except urllib.error.HTTPError as e:
         print(f"Gemini API error: {e.code} - {e.read().decode()}")
-        # Fallback: try text-to-image with gemini-2.0-flash
+        # Fallback: try text-to-image with gemini-3-pro-preview
         return generate_with_gemini_flash(title, api_key)
 
     return None
 
 
 def generate_with_gemini_flash(title, api_key):
-    """Fallback: use gemini-2.0-flash-exp for image generation."""
+    """Fallback: use gemini-3-pro-preview for image generation."""
     try:
         import google.generativeai as genai
 
         genai.configure(api_key=api_key)
-        model = genai.GenerativeModel("gemini-2.0-flash-exp")
+        model = genai.GenerativeModel("gemini-3-pro-preview")
 
         prompt = (
             f'Generate an image: minimalist abstract blog header for "{title}". '

--- a/.github/scripts/post_to_linkedin.py
+++ b/.github/scripts/post_to_linkedin.py
@@ -108,7 +108,7 @@ Requirements:
 
 Return ONLY the LinkedIn post text, nothing else."""
 
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key={api_key}"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key={api_key}"
 
     payload = json.dumps({
         "contents": [{"parts": [{"text": prompt}]}],

--- a/.github/scripts/transcribe.py
+++ b/.github/scripts/transcribe.py
@@ -92,7 +92,7 @@ def upload_audio_to_gemini(audio_path, api_key):
 
 def transcribe_with_gemini(file_uri, api_key, post_title):
     """Use Gemini to transcribe the audio with timestamps."""
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key={api_key}"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key={api_key}"
 
     prompt = f"""Transcribe this audio recording in full. This is a vlog/talk titled "{post_title}".
 

--- a/_sass/_custom-hero.scss
+++ b/_sass/_custom-hero.scss
@@ -9,7 +9,7 @@
     display: block;
     width: 100%;
     height: auto;
-    aspect-ratio: #{"1200 / 630"};
+    aspect-ratio: unquote("1200 / 630");
     object-fit: cover;
     border-radius: 0;
   }

--- a/_sass/_custom-typography.scss
+++ b/_sass/_custom-typography.scss
@@ -26,7 +26,7 @@
 }
 
 html {
-  font-size: #{clamp(16px, 1rem + 0.25vw, 19px)};
+  font-size: unquote("clamp(16px, 1rem + 0.25vw, 19px)");
 }
 
 body {
@@ -45,10 +45,10 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--color-text);
 }
 
-h1 { font-size: #{clamp(1.6rem, 4vw, 2.4rem)}; }
-h2 { font-size: #{clamp(1.3rem, 3vw, 1.8rem)}; }
-h3 { font-size: #{clamp(1.1rem, 2.5vw, 1.4rem)}; }
-h4 { font-size: #{clamp(1rem, 2vw, 1.2rem)}; }
+h1 { font-size: unquote("clamp(1.6rem, 4vw, 2.4rem)"); }
+h2 { font-size: unquote("clamp(1.3rem, 3vw, 1.8rem)"); }
+h3 { font-size: unquote("clamp(1.1rem, 2.5vw, 1.4rem)"); }
+h4 { font-size: unquote("clamp(1rem, 2vw, 1.2rem)"); }
 
 code, pre, kbd, samp {
   font-family: "SF Mono", SFMono-Regular, Menlo, Monaco, Consolas,

--- a/_sass/_custom-video.scss
+++ b/_sass/_custom-video.scss
@@ -8,14 +8,14 @@
 
   lite-youtube {
     width: 100%;
-    aspect-ratio: #{"16 / 9"};
+    aspect-ratio: unquote("16 / 9");
     border-radius: 8px;
     overflow: hidden;
   }
 
   iframe {
     width: 100%;
-    aspect-ratio: #{"16 / 9"};
+    aspect-ratio: unquote("16 / 9");
     border: none;
     border-radius: 8px;
   }


### PR DESCRIPTION
## Summary

**LibSass fix (take 2)**: The previous `#{}` interpolation approach still failed because LibSass evaluates expressions inside interpolation blocks. The correct approach is `unquote("...")` which makes the entire value an opaque string that LibSass passes through untouched.

**Gemini model upgrade**: Gemini 2.5 Pro was superseded by Gemini 3 Pro in Dec 2025. Updated all API calls to `gemini-3-pro-preview`:
- LinkedIn copy generation
- Vlog transcription  
- Header image generation fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)